### PR TITLE
To reduce the java.net.SocketTimeoutException, add an `httpTimeout` option.

### DIFF
--- a/autoplay/build.gradle.kts
+++ b/autoplay/build.gradle.kts
@@ -33,7 +33,7 @@ gradlePlugin {
 }
 
 group = "de.halfbit"
-version = "1.0.0"
+version = "1.0.1"
 
 publishing {
 
@@ -100,8 +100,13 @@ publishing {
 
 }
 
-signing {
-    sign(publishing.publications["Autoplay"])
+if (project.hasProperty("signing.keyId")) {
+    plugins {
+        id("org.gradle.signing")
+    }
+    signing {
+        sign(publishing.publications["Autoplay"])
+    }
 }
 
 fun Project.getPropertyOrEmptyString(name: String): String {

--- a/autoplay/src/main/kotlin/de/halfbit/tools/autoplay/AutoplayPublisherExtension.kt
+++ b/autoplay/src/main/kotlin/de/halfbit/tools/autoplay/AutoplayPublisherExtension.kt
@@ -29,4 +29,5 @@ internal open class AutoplayPublisherExtension {
     var secretJsonPath: String? = null
     var releaseNotesPath: String? = RELEASE_NOTES_PATH
     var artifactType = ArtifactType.Apk.name
+    var httpTimeout: Int? = null
 }

--- a/autoplay/src/main/kotlin/de/halfbit/tools/autoplay/AutoplayPublisherPlugin.kt
+++ b/autoplay/src/main/kotlin/de/halfbit/tools/autoplay/AutoplayPublisherPlugin.kt
@@ -59,6 +59,7 @@ internal class PlayPublisherPlugin : Plugin<Project> {
                         releaseStatus = extension.getReleaseStatus()
                         releaseNotes = extension.getReleaseNotes(project.projectDir)
                         credentials = extension.getCredentials()
+                        httpTimeout = extension.httpTimeout
                     }
                 }
 
@@ -74,6 +75,7 @@ internal class PlayPublisherPlugin : Plugin<Project> {
                         releaseStatus = extension.getReleaseStatus()
                         releaseNotes = extension.getReleaseNotes(project.projectDir)
                         credentials = extension.getCredentials()
+                        httpTimeout = extension.httpTimeout
                     }
                 }
             }

--- a/autoplay/src/main/kotlin/de/halfbit/tools/autoplay/PublishTask.kt
+++ b/autoplay/src/main/kotlin/de/halfbit/tools/autoplay/PublishTask.kt
@@ -51,13 +51,16 @@ internal open class PublishTask : DefaultTask() {
     @get:Input
     var releaseStatus: ReleaseStatus = ReleaseStatus.Completed
 
+    @get:Input
+    var httpTimeout: Int? = null
+
     @TaskAction
     @Suppress("UNUSED_PARAMETER", "unused")
     fun execute(inputs: IncrementalTaskInputs) {
         credentials.validate()
 
         V3GooglePlayPublisher
-            .getGooglePlayPublisher(credentials, applicationId)
+            .getGooglePlayPublisher(credentials, applicationId, httpTimeout)
             .publish(
                 ReleaseData(
                     applicationId,


### PR DESCRIPTION
**Modified based on version `1.0.0`**

In China, access to google play must be through VPN, the network is very unstable.
When using the default timeout (20 seconds), the upload often fails with the prompt "java.net.SocketTimeoutException". So I added a "httpTimeout" option.